### PR TITLE
Add create listing page

### DIFF
--- a/src/app/app.tsx
+++ b/src/app/app.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import {
-	ConnectButton,
+        ConnectButton,
 } from "thirdweb/react";
 import { appDescription, appName, client } from "~/constants";
 import { DirectListingList } from "./components/DirectListing/List";
@@ -10,9 +10,9 @@ export default function App() {
 	return (
 		<main className="h-screen w-screen">
 			<div className="w-[300px] mx-auto p-4 h-full">
-				<div className="flex justify-stretch flex-col mb-2 gap-2">
-					<ConnectButton client={client} />
-				</div>
+                                <div className="flex justify-stretch flex-col mb-2 gap-2">
+                                        <ConnectButton client={client} />
+                                </div>
 				<div className="flex justify-stretch flex-col pb-4">
 					{/* eslint-disable-next-line @next/next/no-img-element */}
 					<img src="/logo.png" alt="logo" className="w-24 h-24 mx-auto" />

--- a/src/app/components/DirectListing/List.tsx
+++ b/src/app/components/DirectListing/List.tsx
@@ -1,5 +1,6 @@
 import { useEffect, type FC } from "react";
 import { DirectListingCard } from "./Card";
+import Link from "next/link";
 import { marketplaceContract } from "~/constants";
 import { type DirectListing, getAllValidListings } from "thirdweb/extensions/marketplace";
 import { useState } from "react";
@@ -19,7 +20,12 @@ export const DirectListingList: FC = () => {
   
   return (
     <div>
-      <h1 className="font-bold mb-2">For Sale</h1>
+      <div className="flex items-center mb-2">
+        <h1 className="font-bold flex-1">For Sale</h1>
+        <Link href="/create-listing" className="btn btn-secondary btn-sm">
+          Create Listing
+        </Link>
+      </div>
       <div className="grid grid-cols-2 gap-4 p-2 bg-base-300 rounded-lg">
         {listings.map((listing) => (
           <DirectListingCard

--- a/src/app/create-listing/page.tsx
+++ b/src/app/create-listing/page.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import {
+  ConnectButton,
+  TransactionButton,
+  useActiveAccount,
+} from "thirdweb/react";
+import { createListing } from "thirdweb/extensions/marketplace";
+import { client, marketplaceContract } from "~/constants";
+import { toast } from "react-toastify";
+
+function parseEther(value: string): bigint {
+  const [whole, fraction = ""] = value.split(".");
+  const frac = (fraction + "000000000000000000").slice(0, 18);
+  return BigInt(whole + frac);
+}
+
+export default function CreateListingPage() {
+  const account = useActiveAccount();
+  const [tokenAddress, setTokenAddress] = useState("");
+  const [tokenId, setTokenId] = useState("");
+  const [price, setPrice] = useState("");
+
+  return (
+    <main className="bg-base-400 h-screen w-screen">
+      <div className="w-[300px] mx-auto p-4 bg-base-300 rounded-lg h-full overflow-y-auto space-y-4">
+        <div className="mb-2">
+          <Link href="/" className="btn btn-sm btn-ghost">
+            ← Back
+          </Link>
+        </div>
+        <input
+          type="text"
+          placeholder="NFT Token Address"
+          value={tokenAddress}
+          onChange={(e) => setTokenAddress(e.target.value)}
+          className="input input-bordered input-sm w-full"
+        />
+        <input
+          type="text"
+          placeholder="Token ID"
+          value={tokenId}
+          onChange={(e) => setTokenId(e.target.value)}
+          className="input input-bordered input-sm w-full"
+        />
+        <input
+          type="text"
+          placeholder="Price (ETH)"
+          value={price}
+          onChange={(e) => setPrice(e.target.value)}
+          className="input input-bordered input-sm w-full"
+        />
+        <div className="flex justify-end pt-2">
+          {!account ? (
+            <ConnectButton client={client} />
+          ) : (
+            <TransactionButton
+              transaction={() =>
+                createListing({
+                  contract: marketplaceContract,
+                  assetContractAddress: tokenAddress as `0x${string}`,
+                  tokenId: BigInt(tokenId),
+                  quantity: 1n,
+                  pricePerToken: parseEther(price),
+                })
+              }
+              className="!btn !btn-primary !btn-sm"
+              onTransactionSent={() => toast.loading("Creating listing...")}
+              onTransactionConfirmed={() => {
+                toast.dismiss();
+                toast.success("Listing created!");
+              }}
+              onError={(err) => {
+                toast.dismiss();
+                toast.error(err.message);
+              }}
+            >
+              Create Listing
+            </TransactionButton>
+          )}
+        </div>
+      </div>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- add a form to create a direct listing using the marketplace extension
- link from the listings header to the new listing page
- move listing creation button next to the "For Sale" heading

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6844b647ab8483318daf515a4ed1f4cd