### PR TITLE
Add auction creation page and button

### DIFF
--- a/src/app/auction/create/page.tsx
+++ b/src/app/auction/create/page.tsx
@@ -1,0 +1,146 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import {
+  ConnectButton,
+  TransactionButton,
+  useActiveAccount,
+} from "thirdweb/react";
+import { createAuction } from "thirdweb/extensions/marketplace";
+import { client, marketplaceContract } from "~/constants";
+import { toast } from "react-toastify";
+
+export default function CreateAuctionPage() {
+  const account = useActiveAccount();
+  const [tokenAddress, setTokenAddress] = useState("");
+  const [tokenId, setTokenId] = useState("");
+  const [quantity, setQuantity] = useState("");
+  const [currencyAddress, setCurrencyAddress] = useState("");
+  const [startTime, setStartTime] = useState("");
+  const [endTime, setEndTime] = useState("");
+  const [timeBuffer, setTimeBuffer] = useState("");
+  const [bidBuffer, setBidBuffer] = useState("");
+  const [minBid, setMinBid] = useState("");
+  const [buyoutBid, setBuyoutBid] = useState("");
+
+  return (
+    <main className="bg-base-400 h-screen w-screen">
+      <div className="w-[300px] mx-auto p-4 bg-base-300 rounded-lg h-full overflow-y-auto space-y-4">
+        <div className="mb-2">
+          <Link href="/" className="btn btn-sm btn-ghost">
+            ← Back
+          </Link>
+        </div>
+        <input
+          type="text"
+          placeholder="NFT Token Address"
+          value={tokenAddress}
+          onChange={(e) => setTokenAddress(e.target.value)}
+          className="input input-bordered input-sm w-full"
+        />
+        <input
+          type="text"
+          placeholder="Token ID"
+          value={tokenId}
+          onChange={(e) => setTokenId(e.target.value)}
+          className="input input-bordered input-sm w-full"
+        />
+        <input
+          type="text"
+          placeholder="Quantity"
+          value={quantity}
+          onChange={(e) => setQuantity(e.target.value)}
+          className="input input-bordered input-sm w-full"
+        />
+        <input
+          type="text"
+          placeholder="Currency Address"
+          value={currencyAddress}
+          onChange={(e) => setCurrencyAddress(e.target.value)}
+          className="input input-bordered input-sm w-full"
+        />
+        <input
+          type="datetime-local"
+          placeholder="Start Time"
+          value={startTime}
+          onChange={(e) => setStartTime(e.target.value)}
+          className="input input-bordered input-sm w-full"
+        />
+        <input
+          type="datetime-local"
+          placeholder="End Time"
+          value={endTime}
+          onChange={(e) => setEndTime(e.target.value)}
+          className="input input-bordered input-sm w-full"
+        />
+        <input
+          type="text"
+          placeholder="Time Buffer (s)"
+          value={timeBuffer}
+          onChange={(e) => setTimeBuffer(e.target.value)}
+          className="input input-bordered input-sm w-full"
+        />
+        <input
+          type="text"
+          placeholder="Bid Buffer (bps)"
+          value={bidBuffer}
+          onChange={(e) => setBidBuffer(e.target.value)}
+          className="input input-bordered input-sm w-full"
+        />
+        <input
+          type="text"
+          placeholder="Minimum Bid (ETH)"
+          value={minBid}
+          onChange={(e) => setMinBid(e.target.value)}
+          className="input input-bordered input-sm w-full"
+        />
+        <input
+          type="text"
+          placeholder="Buyout Bid (ETH)"
+          value={buyoutBid}
+          onChange={(e) => setBuyoutBid(e.target.value)}
+          className="input input-bordered input-sm w-full"
+        />
+        <div className="flex justify-end pt-2">
+          {!account ? (
+            <ConnectButton client={client} />
+          ) : (
+            <TransactionButton
+              transaction={() =>
+                createAuction({
+                  contract: marketplaceContract,
+                  assetContractAddress: tokenAddress as `0x${string}`,
+                  tokenId: BigInt(tokenId),
+                  quantity: quantity ? BigInt(quantity) : undefined,
+                  currencyContractAddress: currencyAddress
+                    ? (currencyAddress as `0x${string}`)
+                    : undefined,
+                  startTimestamp: startTime ? new Date(startTime) : undefined,
+                  endTimestamp: endTime ? new Date(endTime) : undefined,
+                  timeBufferInSeconds: timeBuffer ? Number(timeBuffer) : undefined,
+                  bidBufferBps: bidBuffer ? Number(bidBuffer) : undefined,
+                  minimumBidAmount: minBid,
+                  buyoutBidAmount: buyoutBid,
+                })
+              }
+              className="!btn !btn-primary !btn-sm"
+              onTransactionSent={() => toast.loading("Creating auction...")}
+              onTransactionConfirmed={() => {
+                toast.dismiss();
+                toast.success("Auction created!");
+              }}
+              onError={(err) => {
+                toast.dismiss();
+                toast.error(err.message);
+              }}
+            >
+              Create Auction
+            </TransactionButton>
+          )}
+        </div>
+      </div>
+    </main>
+  );
+}
+

--- a/src/app/components/Auction/List.tsx
+++ b/src/app/components/Auction/List.tsx
@@ -1,4 +1,5 @@
 import { useEffect, type FC, useState } from "react";
+import Link from "next/link";
 import { AuctionCard } from "./Card";
 import { marketplaceContract } from "~/constants";
 import { type EnglishAuction, getAllValidAuctions } from "thirdweb/extensions/marketplace";
@@ -18,7 +19,12 @@ export const AuctionList: FC = () => {
 
   return (
     <div className="mt-6">
-      <h1 className="font-bold mb-2">Auctions</h1>
+      <div className="flex items-center mb-2">
+        <h1 className="font-bold flex-1">Auctions</h1>
+        <Link href="/auction/create" className="btn btn-secondary btn-sm">
+          Create Auction
+        </Link>
+      </div>
       <div className="grid grid-cols-2 gap-4 p-2 bg-base-300 rounded-lg">
         {auctions.map((auction) => (
           <AuctionCard key={auction.id} auction={auction} />


### PR DESCRIPTION
## Summary
- add create auction button in auction list header
- implement `/auction/create` page with form for all auction fields

## Testing
- `bun run lint`


------
https://chatgpt.com/codex/tasks/task_e_68450c81e1f0833185b9bb9d148c4922