### PR TITLE
Make listings horizontally scrollable

### DIFF
--- a/src/app/components/Auction/List.tsx
+++ b/src/app/components/Auction/List.tsx
@@ -25,9 +25,11 @@ export const AuctionList: FC = () => {
           Create Auction
         </Link>
       </div>
-      <div className="grid grid-cols-2 gap-4 p-2 bg-base-300 rounded-lg">
+      <div className="flex overflow-x-auto gap-4 p-2 bg-base-300 rounded-lg">
         {auctions.map((auction) => (
-          <AuctionCard key={auction.id} auction={auction} />
+          <div key={auction.id} className="shrink-0 w-40">
+            <AuctionCard auction={auction} />
+          </div>
         ))}
       </div>
     </div>

--- a/src/app/components/DirectListing/List.tsx
+++ b/src/app/components/DirectListing/List.tsx
@@ -26,12 +26,11 @@ export const DirectListingList: FC = () => {
           Create Listing
         </Link>
       </div>
-      <div className="grid grid-cols-2 gap-4 p-2 bg-base-300 rounded-lg">
+      <div className="flex overflow-x-auto gap-4 p-2 bg-base-300 rounded-lg">
         {listings.map((listing) => (
-          <DirectListingCard
-            key={listing.id}
-            listing={listing}
-          />
+          <div key={listing.id} className="shrink-0 w-40">
+            <DirectListingCard listing={listing} />
+          </div>
         ))}
       </div>
     </div>


### PR DESCRIPTION
## Summary
- switch listing containers to flex row with overflow scroll
- give each card a fixed width so it scrolls horizontally

## Testing
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6845121af0688331b0b372c6707ee60e