### PR TITLE
Hide pause button on NFTMedia videos

### DIFF
--- a/src/app/auction/[id]/page.tsx
+++ b/src/app/auction/[id]/page.tsx
@@ -96,7 +96,7 @@ export default function AuctionPage() {
 
         <NFTProvider contract={contract} tokenId={BigInt(auction.asset.id)}>
           <div className="card bg-base-100 shadow-xl">
-            <NFTMedia className="w-full h-64 object-cover" />
+            <NFTMedia className="w-full h-64 object-cover nftmedia-hide-overlay" />
             <div className="card-body p-4">
               <h2 className="card-title">
                 <NFTName />

--- a/src/app/components/Auction/Card.tsx
+++ b/src/app/components/Auction/Card.tsx
@@ -29,7 +29,7 @@ export const AuctionCard: FC<Props> = ({ auction }) => {
         onClick={handleCardClick}
       >
         <figure>
-          <NFTMedia />
+          <NFTMedia className="nftmedia-hide-overlay" />
         </figure>
         <div className="card-body p-2 gap-0">
           <h2 className="text-sm font-semibold truncate block w-full">

--- a/src/app/components/DirectListing/Card.tsx
+++ b/src/app/components/DirectListing/Card.tsx
@@ -28,7 +28,7 @@ export const DirectListingCard: FC<Props> = ({ listing }) => {
         onClick={handleCardClick}
       >
         <figure>
-          <NFTMedia />
+          <NFTMedia className="nftmedia-hide-overlay" />
         </figure>
         <div className="card-body p-2 gap-0">
           <h2 className="text-sm font-semibold truncate block w-full">{listing.asset.metadata.name}</h2>

--- a/src/app/direct-listing/[id]/page.tsx
+++ b/src/app/direct-listing/[id]/page.tsx
@@ -91,7 +91,7 @@ export default function DirectListingPage() {
         
         <NFTProvider contract={contract} tokenId={BigInt(listing.asset.id)}>
           <div className="card bg-base-100 shadow-xl">
-            <NFTMedia className="w-full h-64 object-cover" />
+            <NFTMedia className="w-full h-64 object-cover nftmedia-hide-overlay" />
             <div className="card-body p-4">
               <h2 className="card-title">
                 <NFTName />

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -31,3 +31,9 @@ body {
 *::-webkit-scrollbar {
   display: none;
 }
+
+/* Hide pause overlay button from thirdweb's NFTMedia component */
+.nftmedia-hide-overlay button {
+  display: none !important;
+}
+


### PR DESCRIPTION
## Summary
- hide pause overlay of NFTMedia with global style
- apply the new class to all NFTMedia components

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68459a8411c08331aea96658e5ea1603