### PR TITLE
Fix card alignment

### DIFF
--- a/src/app/components/Auction/List.tsx
+++ b/src/app/components/Auction/List.tsx
@@ -23,7 +23,7 @@ export const AuctionList: FC = () => {
           Create Auction
         </Link>
       </div>
-      <div className="flex overflow-x-auto gap-4 p-2 bg-base-300 rounded-lg">
+        <div className="flex items-end overflow-x-auto gap-4 p-2 bg-base-300 rounded-lg">
         {auctions.map((auction) => (
           <div key={auction.id} className="shrink-0 w-40">
             <AuctionCard auction={auction} />

--- a/src/app/components/DirectListing/List.tsx
+++ b/src/app/components/DirectListing/List.tsx
@@ -24,7 +24,7 @@ export const DirectListingList: FC = () => {
           Create Listing
         </Link>
       </div>
-      <div className="flex overflow-x-auto gap-4 p-2 bg-base-300 rounded-lg">
+      <div className="flex items-end overflow-x-auto gap-4 p-2 bg-base-300 rounded-lg">
         {listings.map((listing) => (
           <div key={listing.id} className="shrink-0 w-40">
             <DirectListingCard listing={listing} />


### PR DESCRIPTION
## Summary
- align bottom of horizontally scrolling listing cards
- align bottom of horizontally scrolling auction cards

## Testing
- `bun run lint`
- `bun run build` *(fails: Creating an optimized production build...)*

------
https://chatgpt.com/codex/tasks/task_e_6845a3223e04833181d4ecd4ca2dd5cc