### PR TITLE
Add winning bid info for auctions

### DIFF
--- a/src/app/auction/[id]/page.tsx
+++ b/src/app/auction/[id]/page.tsx
@@ -194,30 +194,31 @@ export default function AuctionPage() {
                   <Account address={auction.creatorAddress} />
                 </div>
                 {auction.winningBid && (
-                  <div className="flex justify-between">
+                  <div className="flex justify-between items-start">
                     <span className="font-semibold">Winning Bid:</span>
-                    <span className="flex items-center gap-1">
+                    <div className="flex flex-col items-end gap-1">
                       <Account
                         address={auction.winningBid.bidderAddress}
                         avatarClassName="w-4 h-4"
                         className="max-w-[100px]"
                       />
-                      <TokenProvider
-                        address={auction.currencyContractAddress as `0x${string}`}
-                        client={client}
-                        chain={chain}
-                      >
-                        <TokenIcon
-                          className="w-4 h-4"
-                          iconResolver={`/api/token-image?chainName=${chain.name}&tokenAddress=${auction.currencyContractAddress}`}
-                          loadingComponent={<TokenIconFallback />}
-                          fallbackComponent={<TokenIconFallback />}
-                        />
-                      </TokenProvider>
-                      {auction.winningBid.currencyValue.displayValue}
-                      {" "}
-                      {auction.winningBid.currencyValue.symbol}
-                    </span>
+                      <span className="flex items-center gap-1">
+                        <TokenProvider
+                          address={auction.currencyContractAddress as `0x${string}`}
+                          client={client}
+                          chain={chain}
+                        >
+                          <TokenIcon
+                            className="w-4 h-4"
+                            iconResolver={`/api/token-image?chainName=${chain.name}&tokenAddress=${auction.currencyContractAddress}`}
+                            loadingComponent={<TokenIconFallback />}
+                            fallbackComponent={<TokenIconFallback />}
+                          />
+                        </TokenProvider>
+                        {auction.winningBid.currencyValue.displayValue}{" "}
+                        {auction.winningBid.currencyValue.symbol}
+                      </span>
+                    </div>
                   </div>
                 )}
               </div>

--- a/src/app/auction/[id]/page.tsx
+++ b/src/app/auction/[id]/page.tsx
@@ -8,6 +8,7 @@ import {
   buyoutAuction,
   bidInAuction,
   cancelAuction,
+  getWinningBid,
 } from "thirdweb/extensions/marketplace";
 import { allowance, approve } from "thirdweb/extensions/erc20";
 import { NATIVE_TOKEN_ADDRESS } from "thirdweb";
@@ -31,7 +32,8 @@ import TokenIconFallback from "~/app/components/TokenIconFallback";
 export default function AuctionPage() {
   const params = useParams();
   const auctionId = params.id as string;
-  const [auction, setAuction] = useState<EnglishAuction | null>(null);
+  type WinningBid = Awaited<ReturnType<typeof getWinningBid>>;
+  const [auction, setAuction] = useState<(EnglishAuction & { winningBid?: WinningBid }) | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const account = useActiveAccount();
@@ -72,7 +74,7 @@ export default function AuctionPage() {
         setLoading(true);
         const res = await fetch(`/api/auctions/${auctionId}`);
         if (!res.ok) throw new Error();
-        const auctionData: EnglishAuction = await res.json();
+        const auctionData: EnglishAuction & { winningBid?: WinningBid } = await res.json();
         setAuction(auctionData);
       } catch (err) {
         setError("Failed to load auction");
@@ -191,6 +193,33 @@ export default function AuctionPage() {
                   <span className="font-semibold">Seller:</span>
                   <Account address={auction.creatorAddress} />
                 </div>
+                {auction.winningBid && (
+                  <div className="flex justify-between">
+                    <span className="font-semibold">Winning Bid:</span>
+                    <span className="flex items-center gap-1">
+                      <Account
+                        address={auction.winningBid.bidderAddress}
+                        avatarClassName="w-4 h-4"
+                        className="max-w-[100px]"
+                      />
+                      <TokenProvider
+                        address={auction.currencyContractAddress as `0x${string}`}
+                        client={client}
+                        chain={chain}
+                      >
+                        <TokenIcon
+                          className="w-4 h-4"
+                          iconResolver={`/api/token-image?chainName=${chain.name}&tokenAddress=${auction.currencyContractAddress}`}
+                          loadingComponent={<TokenIconFallback />}
+                          fallbackComponent={<TokenIconFallback />}
+                        />
+                      </TokenProvider>
+                      {auction.winningBid.currencyValue.displayValue}
+                      {" "}
+                      {auction.winningBid.currencyValue.symbol}
+                    </span>
+                  </div>
+                )}
               </div>
 
               <div className="card-actions justify-end mt-4">


### PR DESCRIPTION
## Summary
- fetch winning bid in `/api/auctions/[id]` and include it in cache
- display winning bid amount and bidder on the auction page

## Testing
- `bun run lint`


------
https://chatgpt.com/codex/tasks/task_e_6845b602942c8331bf39e52096926db8