### PR TITLE
Enable PayEmbed modal for NFT purchases

### DIFF
--- a/src/app/auction/[id]/page.tsx
+++ b/src/app/auction/[id]/page.tsx
@@ -9,7 +9,6 @@ import {
   bidInAuction,
   cancelAuction,
   getWinningBid,
-  isNewWinningBid,
 } from "thirdweb/extensions/marketplace";
 import { allowance, approve } from "thirdweb/extensions/erc20";
 import { NATIVE_TOKEN_ADDRESS } from "thirdweb";
@@ -18,6 +17,7 @@ import {
   NFTMedia,
   NFTName,
   NFTDescription,
+  PayEmbed,
   TransactionButton,
   useActiveAccount,
   ConnectButton,
@@ -41,9 +41,7 @@ export default function AuctionPage() {
   const [error, setError] = useState<string | null>(null);
   const account = useActiveAccount();
   const [hasAllowance, setHasAllowance] = useState(false);
-  const [bidModalOpen, setBidModalOpen] = useState(false);
-  const [bidAmount, setBidAmount] = useState("");
-  const [isNewWinner, setIsNewWinner] = useState(true);
+  const [openModal, setOpenModal] = useState<"bid" | "buyout" | null>(null);
   const isNativeToken = (address: string) =>
     address.toLowerCase() === NATIVE_TOKEN_ADDRESS.toLowerCase();
 
@@ -84,42 +82,14 @@ export default function AuctionPage() {
           owner: account.address,
           spender: marketplaceContract.address,
         });
-        const amountWei = toUnits(bidAmount || minBidDisplay, decimals);
-        setHasAllowance(value >= amountWei);
+        setHasAllowance(value >= minNextBidWei);
       } catch (err) {
         console.error(err);
         setHasAllowance(false);
       }
     };
     checkAllowance();
-  }, [account, auction, bidAmount, minBidDisplay]);
-
-  useEffect(() => {
-    if (auction) {
-      setBidAmount(minBidDisplay);
-    }
-  }, [auction, minBidDisplay]);
-
-  useEffect(() => {
-    const validateBid = async () => {
-      if (!auction || !bidAmount) {
-        setIsNewWinner(false);
-        return;
-      }
-      try {
-        const valid = await isNewWinningBid({
-          contract: marketplaceContract,
-          auctionId: BigInt(auction.id),
-          bidAmount: toUnits(bidAmount, decimals),
-        });
-        setIsNewWinner(valid);
-      } catch (err) {
-        console.error(err);
-        setIsNewWinner(false);
-      }
-    };
-    validateBid();
-  }, [bidAmount, auction, decimals]);
+  }, [account, auction, minNextBidWei]);
 
   useEffect(() => {
     const fetchAuction = async () => {
@@ -174,10 +144,6 @@ export default function AuctionPage() {
     client,
     address: auction.asset.tokenAddress as `0x${string}`,
   });
-
-  const bidAmountWei = toUnits(bidAmount || "0", decimals);
-  const isBidValid =
-    bidAmount !== "" && bidAmountWei >= minNextBidWei && isNewWinner;
 
   return (
     <main className="bg-base-400 h-screen w-screen">
@@ -289,38 +255,117 @@ export default function AuctionPage() {
                   <ConnectButton client={client} />
                 ) : (
                   <>
-                    <button
-                      className="btn btn-primary btn-sm"
-                      onClick={() => setBidModalOpen(true)}
-                    >
-                      Bid
-                    </button>
-                    <TransactionButton
-                      transaction={() =>
-                        buyoutAuction({
-                          contract: marketplaceContract,
-                          auctionId: BigInt(auction.id),
-                        })
-                      }
-                      className="!btn !btn-secondary !btn-sm"
-                      onTransactionSent={() => {
-                        toast.loading("Buying out auction...");
-                      }}
-                      onTransactionConfirmed={() => {
-                        toast.dismiss();
-                        toast.success("Auction bought out!");
-                        fetch("/api/cache/invalidate", {
-                          method: "POST",
-                          body: JSON.stringify({ keys: ["auctions", `auction:${auction.id}`] }),
-                        });
-                      }}
-                      onError={(error: Error) => {
-                        toast.dismiss();
-                        toast.error(error.message);
-                      }}
-                    >
-                      Buyout
-                    </TransactionButton>
+                    {hasAllowance ? (
+                      <>
+                        <button
+                          className="btn btn-primary btn-sm"
+                          onClick={() => setOpenModal("bid")}
+                        >
+                          Bid
+                        </button>
+                        {openModal === "bid" && (
+                          <div className="fixed inset-0 z-50 grid place-items-center bg-black/50">
+                            <div className="relative">
+                              <button
+                                className="btn btn-xs btn-circle absolute right-2 top-2"
+                                onClick={() => setOpenModal(null)}
+                              >
+                                ✕
+                              </button>
+                              <PayEmbed
+                                client={client}
+                                payOptions={{
+                                  mode: "transaction",
+                                  transaction: bidInAuction({
+                                    contract: marketplaceContract,
+                                    auctionId: BigInt(auction.id),
+                                    bidAmountWei: minNextBidWei,
+                                  }),
+                                  metadata: auction.asset.metadata,
+                                  onPurchaseSuccess: () => {
+                                    toast.success("Bid placed!");
+                                    fetch("/api/cache/invalidate", {
+                                      method: "POST",
+                                      body: JSON.stringify({ keys: [`auction:${auction.id}`] }),
+                                    });
+                                    setOpenModal(null);
+                                  },
+                                }}
+                              />
+                            </div>
+                          </div>
+                        )}
+                      </>
+                    ) : (
+                      <TransactionButton
+                        transaction={() => {
+                          const erc20 = getContract({
+                            address: auction.currencyContractAddress as `0x${string}`,
+                            chain,
+                            client,
+                          });
+                          return approve({
+                            contract: erc20,
+                            spender: marketplaceContract.address,
+                            amountWei: minNextBidWei,
+                          });
+                        }}
+                        className="!btn !btn-primary !btn-sm"
+                        onTransactionSent={() => {
+                          toast.loading("Approving currency...");
+                        }}
+                        onTransactionConfirmed={() => {
+                          toast.dismiss();
+                          toast.success("Currency approved");
+                          setHasAllowance(true);
+                        }}
+                        onError={(error) => {
+                          toast.dismiss();
+                          toast.error(error.message);
+                        }}
+                      >
+                        Approve
+                      </TransactionButton>
+                    )}
+                    <>
+                      <button
+                        className="btn btn-secondary btn-sm"
+                        onClick={() => setOpenModal("buyout")}
+                      >
+                        Buyout
+                      </button>
+                      {openModal === "buyout" && (
+                        <div className="fixed inset-0 z-50 grid place-items-center bg-black/50">
+                          <div className="relative">
+                            <button
+                              className="btn btn-xs btn-circle absolute right-2 top-2"
+                              onClick={() => setOpenModal(null)}
+                            >
+                              ✕
+                            </button>
+                            <PayEmbed
+                              client={client}
+                              payOptions={{
+                                mode: "transaction",
+                                transaction: buyoutAuction({
+                                  contract: marketplaceContract,
+                                  auctionId: BigInt(auction.id),
+                                }),
+                                metadata: auction.asset.metadata,
+                                onPurchaseSuccess: () => {
+                                  toast.success("Auction bought out!");
+                                  fetch("/api/cache/invalidate", {
+                                    method: "POST",
+                                    body: JSON.stringify({ keys: ["auctions", `auction:${auction.id}`] }),
+                                  });
+                                  setOpenModal(null);
+                                },
+                              }}
+                            />
+                          </div>
+                        </div>
+                      )}
+                    </>
                   </>
                 )}
                 {account?.address?.toLowerCase() === auction.creatorAddress.toLowerCase() && (
@@ -355,101 +400,6 @@ export default function AuctionPage() {
             </div>
           </div>
         </NFTProvider>
-        {bidModalOpen && (
-          <dialog className="modal modal-open">
-            <div className="modal-box space-y-2">
-              <h3 className="font-bold text-lg">Place Bid</h3>
-              <p className="text-sm">
-                Minimum Next Bid: {minBidDisplay} {auction.minimumBidCurrencyValue.symbol}
-              </p>
-              <div className="flex items-center gap-2">
-                <input
-                  type="number"
-                  step="any"
-                  value={bidAmount}
-                  onChange={(e) => setBidAmount(e.target.value)}
-                  className={`input input-bordered input-sm flex-1 ${bidAmount && !isBidValid ? "input-error" : ""}`}
-                />
-                <button
-                  className="btn btn-xs"
-                  onClick={() => setBidAmount(minBidDisplay)}
-                >
-                  Use Min
-                </button>
-              </div>
-              {!isBidValid && bidAmount && (
-                <p className="text-error text-xs">Bid must be at least {minBidDisplay} {auction.minimumBidCurrencyValue.symbol}</p>
-              )}
-              <div className="modal-action">
-                <button className="btn btn-sm" onClick={() => setBidModalOpen(false)}>
-                  Close
-                </button>
-                {hasAllowance ? (
-                  <TransactionButton
-                    transaction={() =>
-                      bidInAuction({
-                        contract: marketplaceContract,
-                        auctionId: BigInt(auction.id),
-                        bidAmountWei: toUnits(bidAmount, decimals),
-                      })
-                    }
-                    disabled={!isBidValid}
-                    className="!btn !btn-primary !btn-sm"
-                    onTransactionSent={() => {
-                      toast.loading("Placing bid...");
-                    }}
-                    onTransactionConfirmed={() => {
-                      setBidModalOpen(false);
-                      toast.dismiss();
-                      toast.success("Bid placed!");
-                      fetch("/api/cache/invalidate", {
-                        method: "POST",
-                        body: JSON.stringify({ keys: [`auction:${auction.id}`] }),
-                      });
-                    }}
-                    onError={(error) => {
-                      toast.dismiss();
-                      toast.error(error.message);
-                    }}
-                  >
-                    Bid
-                  </TransactionButton>
-                ) : (
-                  <TransactionButton
-                    transaction={() => {
-                      const erc20 = getContract({
-                        address: auction.currencyContractAddress as `0x${string}`,
-                        chain,
-                        client,
-                      });
-                      return approve({
-                        contract: erc20,
-                        spender: marketplaceContract.address,
-                        amountWei: toUnits(bidAmount, decimals),
-                      });
-                    }}
-                    disabled={!isBidValid}
-                    className="!btn !btn-primary !btn-sm"
-                    onTransactionSent={() => {
-                      toast.loading("Approving currency...");
-                    }}
-                    onTransactionConfirmed={() => {
-                      toast.dismiss();
-                      toast.success("Currency approved");
-                      setHasAllowance(true);
-                    }}
-                    onError={(error) => {
-                      toast.dismiss();
-                      toast.error(error.message);
-                    }}
-                  >
-                    Approve
-                  </TransactionButton>
-                )}
-              </div>
-            </div>
-          </dialog>
-        )}
       </div>
     </main>
   );

--- a/src/app/components/Auction/Card.tsx
+++ b/src/app/components/Auction/Card.tsx
@@ -1,8 +1,8 @@
-import { type FC } from "react";
+import { type FC, useState } from "react";
 import { getContract } from "thirdweb";
 import { buyoutAuction, type EnglishAuction } from "thirdweb/extensions/marketplace";
 import Countdown from "../Countdown";
-import { NFTProvider, NFTMedia, TransactionButton, useActiveAccount, TokenProvider, TokenIcon } from "thirdweb/react";
+import { NFTProvider, NFTMedia, PayEmbed, useActiveAccount, TokenProvider, TokenIcon } from "thirdweb/react";
 import { chain, client, marketplaceContract } from "~/constants";
 import { useRouter } from "next/navigation";
 import TokenIconFallback from "../TokenIconFallback";
@@ -15,6 +15,7 @@ type Props = {
 export const AuctionCard: FC<Props> = ({ auction }) => {
   const account = useActiveAccount();
   const router = useRouter();
+  const [showPay, setShowPay] = useState(false);
   const contract = getContract({
     chain,
     client,
@@ -63,17 +64,38 @@ export const AuctionCard: FC<Props> = ({ auction }) => {
           </div>
           {account?.address && (
             <div className="card-actions justify-end" onClick={(e) => e.stopPropagation()}>
-              <TransactionButton
-                transaction={() =>
-                  buyoutAuction({
-                    contract: marketplaceContract,
-                    auctionId: auction.id,
-                  })
-                }
-                className="!btn !btn-xs !w-fit !min-w-fit"
+              <button
+                className="btn btn-secondary btn-xs"
+                onClick={() => setShowPay(true)}
               >
                 Buyout
-              </TransactionButton>
+              </button>
+              {showPay && (
+                <div className="fixed inset-0 z-50 grid place-items-center bg-black/50">
+                  <div className="relative">
+                    <button
+                      className="btn btn-xs btn-circle absolute right-2 top-2"
+                      onClick={() => setShowPay(false)}
+                    >
+                      ✕
+                    </button>
+                    <PayEmbed
+                      client={client}
+                      payOptions={{
+                        mode: "transaction",
+                        transaction: buyoutAuction({
+                          contract: marketplaceContract,
+                          auctionId: auction.id,
+                        }),
+                        metadata: auction.asset.metadata,
+                        onPurchaseSuccess: () => {
+                          setShowPay(false);
+                        },
+                      }}
+                    />
+                  </div>
+                </div>
+              )}
             </div>
           )}
         </div>

--- a/src/app/components/Auction/Card.tsx
+++ b/src/app/components/Auction/Card.tsx
@@ -1,12 +1,13 @@
-import { type FC, useState } from "react";
-import { getContract } from "thirdweb";
+import { type FC, useState, useEffect } from "react";
+import { getContract, NATIVE_TOKEN_ADDRESS } from "thirdweb";
 import { buyoutAuction, type EnglishAuction } from "thirdweb/extensions/marketplace";
 import Countdown from "../Countdown";
-import { NFTProvider, NFTMedia, PayEmbed, useActiveAccount, TokenProvider, TokenIcon } from "thirdweb/react";
+import { NFTProvider, NFTMedia, PayEmbed, TransactionButton, useActiveAccount, TokenProvider, TokenIcon } from "thirdweb/react";
 import { chain, client, marketplaceContract } from "~/constants";
 import { useRouter } from "next/navigation";
 import TokenIconFallback from "../TokenIconFallback";
 import { Account } from "~/app/components/Account";
+import { getWalletBalance } from "thirdweb/wallets";
 
 type Props = {
   auction: EnglishAuction;
@@ -16,15 +17,52 @@ export const AuctionCard: FC<Props> = ({ auction }) => {
   const account = useActiveAccount();
   const router = useRouter();
   const [showPay, setShowPay] = useState(false);
+  const [userBalance, setUserBalance] = useState<bigint>(0n);
   const contract = getContract({
     chain,
     client,
     address: auction.asset.tokenAddress as `0x${string}`,
   });
+  const isNativeToken = (address: string) =>
+    address.toLowerCase() === NATIVE_TOKEN_ADDRESS.toLowerCase();
+
+  useEffect(() => {
+    const checkBalance = async () => {
+      if (!account || !auction) return;
+      try {
+        const balance = await getWalletBalance({
+          address: account.address,
+          client,
+          chain,
+          tokenAddress: isNativeToken(auction.currencyContractAddress) 
+            ? undefined 
+            : auction.currencyContractAddress,
+        });
+        setUserBalance(balance.value);
+      } catch (err) {
+        console.error("Error checking balance:", err);
+        setUserBalance(0n);
+      }
+    };
+    checkBalance();
+  }, [account, auction]);
 
   const handleCardClick = () => {
     router.push(`/auction/${auction.id}`);
   };
+
+  // Common success handler
+  const handleBuyoutSuccess = () => {
+    setShowPay(false);
+  };
+
+  // Transaction generator
+  const getBuyoutTransaction = () => buyoutAuction({
+    contract: marketplaceContract,
+    auctionId: auction.id,
+  });
+
+  const hasSufficientBalance = userBalance >= BigInt(auction?.buyoutCurrencyValue?.value || 0);
 
   return (
     <NFTProvider contract={contract} tokenId={BigInt(auction.asset.id)}>
@@ -64,17 +102,29 @@ export const AuctionCard: FC<Props> = ({ auction }) => {
           </div>
           {account?.address && (
             <div className="card-actions justify-end" onClick={(e) => e.stopPropagation()}>
-              <button
-                className="btn btn-secondary btn-xs"
-                onClick={() => setShowPay(true)}
-              >
-                Buyout
-              </button>
+              {hasSufficientBalance ? (
+                <TransactionButton
+                  transaction={getBuyoutTransaction}
+                  className="!btn !btn-secondary !btn-xs !text-xs !min-w-fit"
+                >
+                  Buyout
+                </TransactionButton>
+              ) : (
+                <button
+                  className="btn btn-outline btn-xs text-xs px-2 min-h-6 h-6"
+                  onClick={() => setShowPay(true)}
+                >
+                  Pay with crypto
+                </button>
+              )}
               {showPay && (
-                <div className="fixed inset-0 z-50 grid place-items-center bg-black/50">
-                  <div className="relative">
+                <div 
+                  className="fixed inset-0 z-50 grid place-items-center bg-black/50"
+                  onClick={() => setShowPay(false)}
+                >
+                  <div className="relative" onClick={(e) => e.stopPropagation()}>
                     <button
-                      className="btn btn-xs btn-circle absolute right-2 top-2"
+                      className="btn btn-xs btn-circle absolute right-2 top-2 z-10"
                       onClick={() => setShowPay(false)}
                     >
                       ✕
@@ -83,14 +133,26 @@ export const AuctionCard: FC<Props> = ({ auction }) => {
                       client={client}
                       payOptions={{
                         mode: "transaction",
-                        transaction: buyoutAuction({
-                          contract: marketplaceContract,
-                          auctionId: auction.id,
-                        }),
+                        transaction: getBuyoutTransaction(),
                         metadata: auction.asset.metadata,
-                        onPurchaseSuccess: () => {
-                          setShowPay(false);
+                        buyWithCrypto: {
+                          prefillSource: {
+                            chain: chain,
+                            token: isNativeToken(auction.currencyContractAddress)
+                              ? undefined
+                              : {
+                                  address: auction.currencyContractAddress,
+                                  name: auction.buyoutCurrencyValue.name,
+                                  symbol: auction.buyoutCurrencyValue.symbol,
+                                  icon: `/api/token-image?chainName=${chain.name}&tokenAddress=${auction.currencyContractAddress}`,
+                                },
+                            allowEdits: {
+                              chain: false,
+                              token: false,
+                            },
+                          },
                         },
+                        onPurchaseSuccess: handleBuyoutSuccess,
                       }}
                     />
                   </div>
@@ -103,4 +165,5 @@ export const AuctionCard: FC<Props> = ({ auction }) => {
     </NFTProvider>
   );
 };
+
 

--- a/src/app/components/DirectListing/Card.tsx
+++ b/src/app/components/DirectListing/Card.tsx
@@ -1,5 +1,5 @@
 import { type FC, useState, useEffect } from "react";
-import { getContract, NATIVE_TOKEN_ADDRESS } from "thirdweb";
+import { getContract, NATIVE_TOKEN_ADDRESS, ZERO_ADDRESS } from "thirdweb";
 import { buyFromListing, type DirectListing } from "thirdweb/extensions/marketplace";
 import Countdown from "../Countdown";
 import { NFTProvider, NFTMedia, PayEmbed, TransactionButton, useActiveAccount, TokenProvider, TokenIcon } from "thirdweb/react";
@@ -60,7 +60,7 @@ export const DirectListingCard: FC<Props> = ({ listing }) => {
     contract: marketplaceContract,
     listingId: listing.id,
     quantity: BigInt(1),
-    recipient: account?.address!,
+    recipient: account?.address || ZERO_ADDRESS,
   });
 
   const hasSufficientBalance = userBalance >= BigInt(listing?.currencyValuePerToken?.value || 0);
@@ -105,6 +105,7 @@ export const DirectListingCard: FC<Props> = ({ listing }) => {
                 <TransactionButton
                   transaction={getBuyTransaction}
                   className="!btn !btn-primary !btn-xs !text-xs !min-w-fit"
+                  disabled={!account?.address}
                 >
                   Buy
                 </TransactionButton>

--- a/src/app/components/DirectListing/Card.tsx
+++ b/src/app/components/DirectListing/Card.tsx
@@ -1,8 +1,8 @@
-import { type FC } from "react";
+import { type FC, useState } from "react";
 import { getContract } from "thirdweb";
 import { buyFromListing, type DirectListing } from "thirdweb/extensions/marketplace";
 import Countdown from "../Countdown";
-import { NFTProvider, NFTMedia, TransactionButton, useActiveAccount, TokenProvider, TokenIcon } from "thirdweb/react";
+import { NFTProvider, NFTMedia, PayEmbed, useActiveAccount, TokenProvider, TokenIcon } from "thirdweb/react";
 import { chain, client, marketplaceContract } from "~/constants";
 import { useRouter } from "next/navigation";
 import TokenIconFallback from "../TokenIconFallback";
@@ -14,6 +14,7 @@ type Props = {
 export const DirectListingCard: FC<Props> = ({ listing }) => {
   const account = useActiveAccount();
   const router = useRouter();
+  const [showPay, setShowPay] = useState(false);
   const contract = getContract({
     chain,
     client,
@@ -60,15 +61,40 @@ export const DirectListingCard: FC<Props> = ({ listing }) => {
           </div>
           {account?.address && (
             <div className="card-actions justify-end" onClick={(e) => e.stopPropagation()}>
-              <TransactionButton
-                transaction={() => buyFromListing({
-                  contract: marketplaceContract,
-                  listingId: listing.id,
-                  quantity: BigInt(1),
-                  recipient: account?.address,
-                })}
-                className="!btn !btn-xs !w-fit !min-w-fit"
-              >Buy Now</TransactionButton>
+              <button
+                className="btn btn-primary btn-xs"
+                onClick={() => setShowPay(true)}
+              >
+                Buy Now
+              </button>
+              {showPay && (
+                <div className="fixed inset-0 z-50 grid place-items-center bg-black/50">
+                  <div className="relative">
+                    <button
+                      className="btn btn-xs btn-circle absolute right-2 top-2"
+                      onClick={() => setShowPay(false)}
+                    >
+                      ✕
+                    </button>
+                    <PayEmbed
+                      client={client}
+                      payOptions={{
+                        mode: "transaction",
+                        transaction: buyFromListing({
+                          contract: marketplaceContract,
+                          listingId: listing.id,
+                          quantity: BigInt(1),
+                          recipient: account?.address,
+                        }),
+                        metadata: listing.asset.metadata,
+                        onPurchaseSuccess: () => {
+                          setShowPay(false);
+                        },
+                      }}
+                    />
+                  </div>
+                </div>
+              )}
             </div>
           )}
         </div>

--- a/src/app/components/DirectListing/Card.tsx
+++ b/src/app/components/DirectListing/Card.tsx
@@ -1,12 +1,13 @@
-import { type FC, useState } from "react";
-import { getContract } from "thirdweb";
+import { type FC, useState, useEffect } from "react";
+import { getContract, NATIVE_TOKEN_ADDRESS } from "thirdweb";
 import { buyFromListing, type DirectListing } from "thirdweb/extensions/marketplace";
 import Countdown from "../Countdown";
-import { NFTProvider, NFTMedia, PayEmbed, useActiveAccount, TokenProvider, TokenIcon } from "thirdweb/react";
+import { NFTProvider, NFTMedia, PayEmbed, TransactionButton, useActiveAccount, TokenProvider, TokenIcon } from "thirdweb/react";
 import { chain, client, marketplaceContract } from "~/constants";
 import { useRouter } from "next/navigation";
 import TokenIconFallback from "../TokenIconFallback";
 import { Account } from "~/app/components/Account";
+import { getWalletBalance } from "thirdweb/wallets";
 
 type Props = {
   listing: DirectListing;
@@ -15,15 +16,54 @@ export const DirectListingCard: FC<Props> = ({ listing }) => {
   const account = useActiveAccount();
   const router = useRouter();
   const [showPay, setShowPay] = useState(false);
+  const [userBalance, setUserBalance] = useState<bigint>(0n);
   const contract = getContract({
     chain,
     client,
     address: listing.asset.tokenAddress as `0x${string}`,
   });
+  const isNativeToken = (address: string) =>
+    address.toLowerCase() === NATIVE_TOKEN_ADDRESS.toLowerCase();
+
+  useEffect(() => {
+    const checkBalance = async () => {
+      if (!account || !listing) return;
+      try {
+        const balance = await getWalletBalance({
+          address: account.address,
+          client,
+          chain,
+          tokenAddress: isNativeToken(listing.currencyContractAddress) 
+            ? undefined 
+            : listing.currencyContractAddress,
+        });
+        setUserBalance(balance.value);
+      } catch (err) {
+        console.error("Error checking balance:", err);
+        setUserBalance(0n);
+      }
+    };
+    checkBalance();
+  }, [account, listing]);
 
   const handleCardClick = () => {
     router.push(`/direct-listing/${listing.id}`);
   };
+
+  // Common success handler
+  const handlePurchaseSuccess = () => {
+    setShowPay(false);
+  };
+
+  // Transaction generator
+  const getBuyTransaction = () => buyFromListing({
+    contract: marketplaceContract,
+    listingId: listing.id,
+    quantity: BigInt(1),
+    recipient: account?.address!,
+  });
+
+  const hasSufficientBalance = userBalance >= BigInt(listing?.currencyValuePerToken?.value || 0);
 
   return (
     <NFTProvider contract={contract} tokenId={BigInt(listing.asset.id)}>
@@ -61,17 +101,29 @@ export const DirectListingCard: FC<Props> = ({ listing }) => {
           </div>
           {account?.address && (
             <div className="card-actions justify-end" onClick={(e) => e.stopPropagation()}>
-              <button
-                className="btn btn-primary btn-xs"
-                onClick={() => setShowPay(true)}
-              >
-                Buy Now
-              </button>
+              {hasSufficientBalance ? (
+                <TransactionButton
+                  transaction={getBuyTransaction}
+                  className="!btn !btn-primary !btn-xs !text-xs !min-w-fit"
+                >
+                  Buy
+                </TransactionButton>
+              ) : (
+                <button
+                  className="btn btn-outline btn-xs text-xs"
+                  onClick={() => setShowPay(true)}
+                >
+                  Pay with crypto
+                </button>
+              )}
               {showPay && (
-                <div className="fixed inset-0 z-50 grid place-items-center bg-black/50">
-                  <div className="relative">
+                <div 
+                  className="fixed inset-0 z-50 grid place-items-center bg-black/50"
+                  onClick={() => setShowPay(false)}
+                >
+                  <div className="relative" onClick={(e) => e.stopPropagation()}>
                     <button
-                      className="btn btn-xs btn-circle absolute right-2 top-2"
+                      className="btn btn-xs btn-circle absolute right-2 top-2 z-10"
                       onClick={() => setShowPay(false)}
                     >
                       ✕
@@ -80,16 +132,26 @@ export const DirectListingCard: FC<Props> = ({ listing }) => {
                       client={client}
                       payOptions={{
                         mode: "transaction",
-                        transaction: buyFromListing({
-                          contract: marketplaceContract,
-                          listingId: listing.id,
-                          quantity: BigInt(1),
-                          recipient: account?.address,
-                        }),
+                        transaction: getBuyTransaction(),
                         metadata: listing.asset.metadata,
-                        onPurchaseSuccess: () => {
-                          setShowPay(false);
+                        buyWithCrypto: {
+                          prefillSource: {
+                            chain: chain,
+                            token: isNativeToken(listing.currencyContractAddress)
+                              ? undefined
+                              : {
+                                  address: listing.currencyContractAddress,
+                                  name: listing.currencyValuePerToken.name,
+                                  symbol: listing.currencyValuePerToken.symbol,
+                                  icon: `/api/token-image?chainName=${chain.name}&tokenAddress=${listing.currencyContractAddress}`,
+                                },
+                            allowEdits: {
+                              chain: false,
+                              token: false,
+                            },
+                          },
                         },
+                        onPurchaseSuccess: handlePurchaseSuccess,
                       }}
                     />
                   </div>
@@ -102,4 +164,6 @@ export const DirectListingCard: FC<Props> = ({ listing }) => {
     </NFTProvider>
   );
 };
+
+
 

--- a/src/app/direct-listing/[id]/page.tsx
+++ b/src/app/direct-listing/[id]/page.tsx
@@ -87,6 +87,7 @@ export default function DirectListingPage() {
     checkBalance();
   }, [account, listing]);
 
+  useEffect(() => {
     const fetchNftInfo = async () => {
       if (!listing) return;
       try {
@@ -270,6 +271,8 @@ export default function DirectListingPage() {
           </div>
         </NFTProvider>
 
+        <CollectionAbout address={listing.asset.tokenAddress} />
+
         {/* Buy Modal */}
         {showBuyModal && (
           <dialog className="modal modal-open">
@@ -363,8 +366,6 @@ export default function DirectListingPage() {
             </div>
           </div>
         )}
-        </NFTProvider>
-        <CollectionAbout address={listing.asset.tokenAddress} />
       </div>
     </main>
   );


### PR DESCRIPTION
## Summary
- switch marketplace purchase buttons to open PayEmbed in a modal
- include listing or auction metadata in PayEmbed options
- remove unsupported PayEmbed props causing type errors

## Testing
- `bun run lint`
- `bun run build`


------
https://chatgpt.com/codex/tasks/task_e_6845c91aeb1c833182505b6ab09b6621