### PR TITLE
Add collection metadata section

### DIFF
--- a/src/app/api/collections/route.ts
+++ b/src/app/api/collections/route.ts
@@ -1,0 +1,67 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getCache, setCache } from "~/lib/cache";
+
+const ZAPPER_URL = "https://public.zapper.xyz/graphql";
+
+const COLLECTION_QUERY = `
+query CollectionMetadata($addresses: [Address!]!) {
+  nftCollections(addresses: $addresses) {
+    address
+    name
+    description
+    logoUrl
+    stats {
+      floorPrice
+    }
+  }
+}`;
+
+export async function GET(request: NextRequest) {
+  const address = request.nextUrl.searchParams.get("address");
+  if (!address) {
+    return NextResponse.json({ error: "address query param is required" }, { status: 400 });
+  }
+
+  const cacheKey = `collection:${address.toLowerCase()}`;
+  const cached = await getCache(cacheKey);
+  if (cached) {
+    return NextResponse.json(cached);
+  }
+
+  try {
+    const variables = { addresses: [address] };
+    const resp = await fetch(ZAPPER_URL, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "x-zapper-api-key": process.env.ZAPPER_API_KEY as string,
+      },
+      body: JSON.stringify({ query: COLLECTION_QUERY, variables }),
+    });
+
+    if (!resp.ok) {
+      const errorText = await resp.text();
+      console.error("Zapper API error:", resp.status, errorText);
+      return NextResponse.json(
+        { error: `Failed to fetch collection: ${resp.status} ${resp.statusText}`, details: errorText },
+        { status: 500 }
+      );
+    }
+
+    const json = await resp.json();
+    if (json.errors) {
+      console.error("GraphQL errors:", json.errors);
+      return NextResponse.json({ error: "GraphQL query failed", details: json.errors }, { status: 500 });
+    }
+
+    const collection = json.data?.nftCollections?.[0] || null;
+    await setCache(cacheKey, collection, { ex: 3600 });
+    return NextResponse.json(collection);
+  } catch (err) {
+    console.error("Unexpected error:", err);
+    return NextResponse.json(
+      { error: "Failed to fetch collection", details: err instanceof Error ? err.message : "Unknown error" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/auction/[id]/page.tsx
+++ b/src/app/auction/[id]/page.tsx
@@ -30,6 +30,7 @@ import { Account } from "~/app/components/Account";
 import Countdown from "~/app/components/Countdown";
 import { toast } from "react-toastify";
 import TokenIconFallback from "~/app/components/TokenIconFallback";
+import { CollectionAbout } from "~/app/components/CollectionAbout";
 import { toTokens, toUnits } from "thirdweb/utils";
 
 export default function AuctionPage() {
@@ -355,6 +356,7 @@ export default function AuctionPage() {
             </div>
           </div>
         </NFTProvider>
+        <CollectionAbout address={auction.asset.tokenAddress} />
         {bidModalOpen && (
           <dialog className="modal modal-open">
             <div className="modal-box space-y-2">

--- a/src/app/components/CollectionAbout.tsx
+++ b/src/app/components/CollectionAbout.tsx
@@ -1,0 +1,44 @@
+"use client";
+import { useEffect, useState } from "react";
+
+type Props = {
+  address: string;
+};
+
+type CollectionData = {
+  name?: string;
+  description?: string;
+  logoUrl?: string;
+  stats?: { floorPrice?: number };
+};
+
+export const CollectionAbout = ({ address }: Props) => {
+  const [data, setData] = useState<CollectionData | null>(null);
+
+  useEffect(() => {
+    async function fetchData() {
+      try {
+        const res = await fetch(`/api/collections?address=${address}`);
+        if (res.ok) {
+          const json = await res.json();
+          setData(json);
+        }
+      } catch (err) {
+        console.error(err);
+      }
+    }
+    if (address) fetchData();
+  }, [address]);
+
+  if (!data) return null;
+
+  return (
+    <section className="mt-4 text-sm">
+      <h3 className="font-bold text-lg mb-2">About {data.name}</h3>
+      {data.description && <p className="mb-2">{data.description}</p>}
+      {data.stats?.floorPrice !== undefined && (
+        <p className="opacity-70">Floor Price: {data.stats.floorPrice}</p>
+      )}
+    </section>
+  );
+};

--- a/src/app/direct-listing/[id]/page.tsx
+++ b/src/app/direct-listing/[id]/page.tsx
@@ -21,6 +21,7 @@ import { Account } from "~/app/components/Account";
 import Countdown from "~/app/components/Countdown";
 import { toast } from "react-toastify";
 import TokenIconFallback from "~/app/components/TokenIconFallback";
+import { CollectionAbout } from "~/app/components/CollectionAbout";
 
 export default function DirectListingPage() {
   const params = useParams();
@@ -206,6 +207,7 @@ export default function DirectListingPage() {
             </div>
           </div>
         </NFTProvider>
+        <CollectionAbout address={listing.asset.tokenAddress} />
       </div>
     </main>
   );


### PR DESCRIPTION
## Summary
- fetch collection metadata from Zapper
- show collection info via new `CollectionAbout` component
- display collection details on auction and direct listing pages

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845e10846b483319133de2cf977e8bf