### PR TITLE
Show NFT attributes on listing pages

### DIFF
--- a/src/app/api/nft/route.ts
+++ b/src/app/api/nft/route.ts
@@ -1,0 +1,67 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getCache, setCache } from "~/lib/cache";
+
+const ZAPPER_URL = "https://public.zapper.xyz/graphql";
+
+const NFT_QUERY = `
+query NftToken($collectionAddress: Address!, $chainId: Int!, $tokenId: String!) {
+  nftTokenV2(collectionAddress: $collectionAddress, chainId: $chainId, tokenId: $tokenId) {
+    tokenId
+    name
+    description
+    rarityRank
+    traits { attributeName attributeValue }
+  }
+}`;
+
+export async function GET(request: NextRequest) {
+  const collectionAddress = request.nextUrl.searchParams.get("collectionAddress");
+  const tokenId = request.nextUrl.searchParams.get("tokenId");
+  const chainIdStr = request.nextUrl.searchParams.get("chainId");
+  const chainId = chainIdStr ? parseInt(chainIdStr, 10) : undefined;
+
+  if (!collectionAddress || !tokenId || !chainId) {
+    return NextResponse.json({ error: "collectionAddress, tokenId and chainId are required" }, { status: 400 });
+  }
+
+  const cacheKey = `nft:${chainId}:${collectionAddress.toLowerCase()}:${tokenId}`;
+  const cached = await getCache(cacheKey);
+  if (cached) {
+    return NextResponse.json(cached, { headers: { "Cache-Control": "public, max-age=31536000, immutable" } });
+  }
+
+  try {
+    const resp = await fetch(ZAPPER_URL, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "x-zapper-api-key": process.env.ZAPPER_API_KEY as string,
+      },
+      body: JSON.stringify({ query: NFT_QUERY, variables: { collectionAddress, chainId, tokenId } }),
+    });
+
+    if (!resp.ok) {
+      const text = await resp.text();
+      console.error("Zapper API error", resp.status, text);
+      return NextResponse.json({ error: "Failed to fetch NFT" }, { status: 500 });
+    }
+
+    const json = await resp.json();
+
+    if (json.errors) {
+      console.error("GraphQL errors", json.errors);
+      return NextResponse.json({ error: "GraphQL query failed" }, { status: 500 });
+    }
+
+    const data = json.data?.nftTokenV2;
+    if (!data) {
+      return NextResponse.json({ error: "NFT not found" }, { status: 404 });
+    }
+
+    await setCache(cacheKey, data); // cache indefinitely
+    return NextResponse.json(data, { headers: { "Cache-Control": "public, max-age=31536000, immutable" } });
+  } catch (err) {
+    console.error("Unexpected error", err);
+    return NextResponse.json({ error: "Failed to fetch NFT" }, { status: 500 });
+  }
+}

--- a/src/app/auction/[id]/page.tsx
+++ b/src/app/auction/[id]/page.tsx
@@ -39,6 +39,13 @@ export default function AuctionPage() {
   const [auction, setAuction] = useState<(EnglishAuction & { winningBid?: WinningBid }) | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [nftInfo, setNftInfo] = useState<
+    | {
+        rarityRank?: number | null;
+        traits: { attributeName: string; attributeValue: string }[];
+      }
+    | null
+  >(null);
   const account = useActiveAccount();
   const [hasAllowance, setHasAllowance] = useState(false);
   const [bidModalOpen, setBidModalOpen] = useState(false);
@@ -92,7 +99,7 @@ export default function AuctionPage() {
       }
     };
     checkAllowance();
-  }, [account, auction, bidAmount, minBidDisplay]);
+  }, [account, auction, bidAmount, minBidDisplay, decimals]);
 
   useEffect(() => {
     if (auction) {
@@ -141,6 +148,23 @@ export default function AuctionPage() {
       fetchAuction();
     }
   }, [auctionId]);
+
+  useEffect(() => {
+    const fetchNftInfo = async () => {
+      if (!auction) return;
+      try {
+        const res = await fetch(
+          `/api/nft?collectionAddress=${auction.asset.tokenAddress}&tokenId=${auction.asset.id}&chainId=${chain.id}`
+        );
+        if (!res.ok) return;
+        const data = await res.json();
+        setNftInfo(data);
+      } catch (err) {
+        console.error('Failed to fetch NFT info', err);
+      }
+    };
+    fetchNftInfo();
+  }, [auction]);
 
   if (loading) {
     return (
@@ -198,6 +222,19 @@ export default function AuctionPage() {
               <div className="text-sm opacity-70">
                 <NFTDescription />
               </div>
+              {nftInfo?.rarityRank && (
+                <p className="text-xs mt-2">Rarity Rank: {nftInfo.rarityRank}</p>
+              )}
+              {nftInfo?.traits?.length ? (
+                <div className="mt-2 grid grid-cols-2 gap-2 text-xs">
+                  {nftInfo.traits.map((t, i) => (
+                    <div key={i} className="border rounded p-2">
+                      <div className="font-semibold">{t.attributeName}</div>
+                      <div>{t.attributeValue}</div>
+                    </div>
+                  ))}
+                </div>
+              ) : null}
 
               <div className="divider"></div>
 

--- a/src/app/direct-listing/[id]/page.tsx
+++ b/src/app/direct-listing/[id]/page.tsx
@@ -28,6 +28,13 @@ export default function DirectListingPage() {
   const [listing, setListing] = useState<DirectListing | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [nftInfo, setNftInfo] = useState<
+    | {
+        rarityRank?: number | null;
+        traits: { attributeName: string; attributeValue: string }[];
+      }
+    | null
+  >(null);
   const account = useActiveAccount();
 
   useEffect(() => {
@@ -50,6 +57,23 @@ export default function DirectListingPage() {
       fetchListing();
     }
   }, [listingId]);
+
+  useEffect(() => {
+    const fetchNftInfo = async () => {
+      if (!listing) return;
+      try {
+        const res = await fetch(
+          `/api/nft?collectionAddress=${listing.asset.tokenAddress}&tokenId=${listing.asset.id}&chainId=${chain.id}`
+        );
+        if (!res.ok) return;
+        const data = await res.json();
+        setNftInfo(data);
+      } catch (err) {
+        console.error('Failed to fetch NFT info', err);
+      }
+    };
+    fetchNftInfo();
+  }, [listing]);
 
   if (loading) {
     return (
@@ -103,6 +127,19 @@ export default function DirectListingPage() {
               <div className="text-sm opacity-70">
                 <NFTDescription />
               </div>
+              {nftInfo?.rarityRank && (
+                <p className="text-xs mt-2">Rarity Rank: {nftInfo.rarityRank}</p>
+              )}
+              {nftInfo?.traits?.length ? (
+                <div className="mt-2 grid grid-cols-2 gap-2 text-xs">
+                  {nftInfo.traits.map((t, i) => (
+                    <div key={i} className="border rounded p-2">
+                      <div className="font-semibold">{t.attributeName}</div>
+                      <div>{t.attributeValue}</div>
+                    </div>
+                  ))}
+                </div>
+              ) : null}
               
               <div className="divider"></div>
               


### PR DESCRIPTION
## Summary
- add API route to fetch NFT traits from Zapper
- display NFT rarity rank and attributes on direct listings and auctions

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68460ae958488331a97f0917c932c04c