### PR TITLE
Add sell button link and default selection

### DIFF
--- a/src/app/components/NFT/Card.tsx
+++ b/src/app/components/NFT/Card.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { FC } from "react";
+import Link from "next/link";
 import { OwnedNFT } from "../NftDropdown";
 
 interface Props {
@@ -26,6 +27,12 @@ export const NFTCard: FC<Props> = ({ nft }) => {
         {nft.quantityOwned && (
           <p className="text-xs opacity-70">Qty: {nft.quantityOwned}</p>
         )}
+        <Link
+          href={`/sell?address=${nft.tokenAddress}&tokenId=${nft.id}`}
+          className="btn btn-primary btn-xs mt-2"
+        >
+          Sell
+        </Link>
       </div>
     </div>
   );

--- a/src/app/components/NftDropdown.tsx
+++ b/src/app/components/NftDropdown.tsx
@@ -12,13 +12,16 @@ export type OwnedNFT = {
 
 type Props = {
   onSelect: (nft: OwnedNFT) => void;
+  selected?: OwnedNFT | null;
 };
 
-export const NftDropdown: FC<Props> = ({ onSelect }) => {
+export const NftDropdown: FC<Props> = ({ onSelect, selected }) => {
   const account = useActiveAccount();
   const [nfts, setNfts] = useState<OwnedNFT[]>([]);
   const [open, setOpen] = useState(false);
-  const [query, setQuery] = useState("");
+  const [query, setQuery] = useState(
+    selected ? selected.metadata.name ?? selected.id : ""
+  );
   const [manual, setManual] = useState(false);
   const [manualAddress, setManualAddress] = useState("");
   const [manualId, setManualId] = useState("");
@@ -27,6 +30,18 @@ export const NftDropdown: FC<Props> = ({ onSelect }) => {
   const [loading, setLoading] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
   const listRef = useRef<HTMLUListElement>(null);
+
+  useEffect(() => {
+    if (selected) {
+      setQuery(selected.metadata.name ? selected.metadata.name : selected.id);
+      setNfts((prev) => {
+        const exists = prev.some(
+          (n) => n.tokenAddress === selected.tokenAddress && n.id === selected.id
+        );
+        return exists ? prev : [selected, ...prev];
+      });
+    }
+  }, [selected]);
 
   useEffect(() => {
     if (!account) return;

--- a/src/app/sell/page.tsx
+++ b/src/app/sell/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from "react";
 import Link from "next/link";
+import { useSearchParams } from "next/navigation";
 import {
   ConnectButton,
   TransactionButton,
@@ -43,6 +44,20 @@ export default function SellPage() {
   const [buyoutBid, setBuyoutBid] = useState("");
   const [price, setPrice] = useState("");
   const [approved, setApproved] = useState(false);
+
+  const searchParams = useSearchParams();
+
+  useEffect(() => {
+    const address = searchParams.get("address");
+    const tokenId = searchParams.get("tokenId");
+    if (address && tokenId) {
+      setSelectedNft({
+        id: tokenId,
+        tokenAddress: address,
+        metadata: {},
+      });
+    }
+  }, [searchParams]);
 
   useEffect(() => {
     const checkApproval = async () => {
@@ -107,7 +122,7 @@ export default function SellPage() {
             Auction
           </label>
         </div>
-        <NftDropdown onSelect={setSelectedNft} />
+        <NftDropdown onSelect={setSelectedNft} selected={selectedNft} />
         {selectedNft && !ownsOneNft && (
           <div>
             <label className="label py-0">


### PR DESCRIPTION
## Summary
- link to the sell page from every NFT card on the My NFTs page
- preselect an NFT on the sell page when opened from a card
- allow NftDropdown to receive a selected NFT
- maintain package.json dependencies

## Testing
- `npx next lint` *(fails: Failed to install required TypeScript dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684625e144648331b5719abca9ad8ef8