### PR TITLE
Truncate description with Read More

### DIFF
--- a/src/app/auction/[id]/page.tsx
+++ b/src/app/auction/[id]/page.tsx
@@ -16,7 +16,6 @@ import {
   NFTProvider,
   NFTMedia,
   NFTName,
-  NFTDescription,
   PayEmbed,
   TransactionButton,
   useActiveAccount,
@@ -33,6 +32,7 @@ import TokenIconFallback from "~/app/components/TokenIconFallback";
 import { CollectionAbout } from "~/app/components/CollectionAbout";
 import { toTokens, toUnits } from "thirdweb/utils";
 import { getWalletBalance } from "thirdweb/wallets";
+import DescriptionWithReadMore from "~/app/components/DescriptionWithReadMore";
 
 export default function AuctionPage() {
   const params = useParams();
@@ -258,9 +258,7 @@ export default function AuctionPage() {
               <h2 className="card-title">
                 <NFTName />
               </h2>
-              <div className="text-sm opacity-70">
-                <NFTDescription />
-              </div>
+              <DescriptionWithReadMore description={auction.asset.metadata.description || ""} />
               {nftInfo?.rarityRank && (
                 <p className="text-xs mt-2">Rarity Rank: {nftInfo.rarityRank}</p>
               )}
@@ -268,8 +266,10 @@ export default function AuctionPage() {
                 <div className="mt-2 grid grid-cols-2 gap-2 text-xs">
                   {nftInfo.traits.map((t, i) => (
                     <div key={i} className="border rounded p-2">
-                      <div className="font-semibold">{t.attributeName}</div>
-                      <div>{t.attributeValue}</div>
+                      <div className="font-semibold truncate">
+                        {t.attributeName}
+                      </div>
+                      <div className="truncate">{t.attributeValue}</div>
                     </div>
                   ))}
                 </div>

--- a/src/app/components/DescriptionWithReadMore.tsx
+++ b/src/app/components/DescriptionWithReadMore.tsx
@@ -25,6 +25,14 @@ const DescriptionWithReadMore: FC<Props> = ({ description }) => {
           Read More
         </button>
       )}
+      {shouldTruncate && expanded && (
+        <span
+          className="underline cursor-pointer ml-1"
+          onClick={() => setExpanded(false)}
+        >
+          Read Less
+        </span>
+      )}
     </div>
   );
 };

--- a/src/app/components/DescriptionWithReadMore.tsx
+++ b/src/app/components/DescriptionWithReadMore.tsx
@@ -1,0 +1,32 @@
+"use client";
+import { FC, useState } from "react";
+
+interface Props {
+  description: string;
+}
+
+const MAX_LENGTH = 320;
+
+const DescriptionWithReadMore: FC<Props> = ({ description }) => {
+  const [expanded, setExpanded] = useState(false);
+  const shouldTruncate = description.length > MAX_LENGTH;
+  const displayed = expanded || !shouldTruncate
+    ? description
+    : description.slice(0, MAX_LENGTH) + "...";
+
+  return (
+    <div className="text-sm opacity-70 whitespace-pre-line">
+      {displayed}
+      {shouldTruncate && !expanded && (
+        <button
+          className="btn btn-link btn-xs px-1 align-baseline"
+          onClick={() => setExpanded(true)}
+        >
+          Read More
+        </button>
+      )}
+    </div>
+  );
+};
+
+export default DescriptionWithReadMore;

--- a/src/app/direct-listing/[id]/page.tsx
+++ b/src/app/direct-listing/[id]/page.tsx
@@ -8,7 +8,6 @@ import {
   NFTProvider,
   NFTMedia,
   NFTName,
-  NFTDescription,
   PayEmbed,
   TransactionButton,
   useActiveAccount,
@@ -24,6 +23,7 @@ import { toast } from "react-toastify";
 import TokenIconFallback from "~/app/components/TokenIconFallback";
 import { getWalletBalance } from "thirdweb/wallets";
 import { CollectionAbout } from "~/app/components/CollectionAbout";
+import DescriptionWithReadMore from "~/app/components/DescriptionWithReadMore";
 
 export default function DirectListingPage() {
   const params = useParams();
@@ -174,9 +174,7 @@ export default function DirectListingPage() {
               <h2 className="card-title">
                 <NFTName />
               </h2>
-              <div className="text-sm opacity-70">
-                <NFTDescription />
-              </div>
+              <DescriptionWithReadMore description={listing.asset.metadata.description || ""} />
               {nftInfo?.rarityRank && (
                 <p className="text-xs mt-2">Rarity Rank: {nftInfo.rarityRank}</p>
               )}
@@ -184,8 +182,10 @@ export default function DirectListingPage() {
                 <div className="mt-2 grid grid-cols-2 gap-2 text-xs">
                   {nftInfo.traits.map((t, i) => (
                     <div key={i} className="border rounded p-2">
-                      <div className="font-semibold">{t.attributeName}</div>
-                      <div>{t.attributeValue}</div>
+                      <div className="font-semibold truncate">
+                        {t.attributeName}
+                      </div>
+                      <div className="truncate">{t.attributeValue}</div>
                     </div>
                   ))}
                 </div>


### PR DESCRIPTION
## Summary
- add new DescriptionWithReadMore component
- truncate NFT description on auction and listing pages
- avoid attribute overflow by truncating trait names and values

## Testing
- `bun x next lint` *(fails: Failed to install required TypeScript dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68462775eae08331a9f626103fac096f