### PR TITLE
Refactor sell page with suspense

### DIFF
--- a/src/app/sell/page.tsx
+++ b/src/app/sell/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { Suspense, useEffect, useState } from "react";
 import Link from "next/link";
 import {
   ConnectButton,
@@ -28,7 +28,7 @@ function toLocal(date: Date) {
   return local.toISOString().slice(0, 16);
 }
 
-export default function SellPage() {
+function SellPageContent() {
   const account = useActiveAccount();
   const [saleType, setSaleType] = useState<"listing" | "auction">("listing");
   const [selectedNft, setSelectedNft] = useState<OwnedNFT | null>(null);
@@ -320,5 +320,13 @@ export default function SellPage() {
         </div>
       </div>
     </main>
+  );
+}
+
+export default function SellPage() {
+  return (
+    <Suspense fallback={null}>
+      <SellPageContent />
+    </Suspense>
   );
 }


### PR DESCRIPTION
## Summary
- create `SellPageContent` component to hold the existing logic
- wrap new component with `<Suspense>` in the page default export
- import `Suspense` from React

## Testing
- `bun install`
- `npm run build` *(fails: `Bus error`)*

------
https://chatgpt.com/codex/tasks/task_e_68462ac07cb883318d6f96e7196296d2